### PR TITLE
use sync interface

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var debug = require('debug')('archive-dat')
 var through = require('through2')
 var tar = require('tar-stream')
 
-module.exports = function create (archive, cb) {
+module.exports = function create (archive) {
   var pack = tar.pack()
   var tarFiles = through.obj(function (entry, enc, next) {
     debug('got', entry)
@@ -22,9 +22,10 @@ module.exports = function create (archive, cb) {
   })
 
   pump(archive.list(), tarFiles, function (err) {
-    if (err) return cb(err)
+    if (err) return pack.destroy(err)
     debug('done!')
     pack.finalize()
-    return cb(null, pack)
   })
+
+  return pack
 }

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "through2": "^2.0.0"
   },
   "devDependencies": {
+    "from2-string": "^1.1.0",
     "hyperdrive": "^6.5.0",
     "memdb": "^1.3.1",
     "random-access-file": "^1.2.0",

--- a/test/index.js
+++ b/test/index.js
@@ -27,11 +27,9 @@ test('check tar contents', function (t) {
 
   archive.finalize(function () {
     t.ok(archive.key.toString('hex'))
-    archiveit(archive, function (err, tar) {
-      t.ifError(err)
-      var extract = extractor(t)
-      tar.pipe(extract)
-    })
+    var tar = archiveit(archive)
+    var extract = extractor(t)
+    tar.pipe(extract)
   })
 })
 
@@ -69,9 +67,10 @@ test('use big file', function (t) {
   var read = from2(crypto.randomBytes(12 * 256 * 100).toString())
   pump(read, ws, function () {
     archive.finalize(function () {
-      console.log(archive.key.toString('hex'))
-      archiveit(archive, function (err, tar) {
-        t.ifError(err)
+      var tar = archiveit(archive)
+
+      tar.resume()
+      tar.on('end', function () {
         t.end()
       })
     })


### PR DESCRIPTION
this was failing before because the pack stream couldn't be drained when it hit max buffer. this pr fixes this by returning the pack stream right away so you can pipe it somewhere else

``` js
var pack = archiveit(archive)
pack.pipe(someOtherStream)
```
